### PR TITLE
fix: Use relative path

### DIFF
--- a/patchright_nodejs_rebranding.js
+++ b/patchright_nodejs_rebranding.js
@@ -99,9 +99,9 @@ fs.rename("packages/playwright-core", "packages/patchright-core", (err) => {
     fs.rename("packages/playwright", "packages/patchright", (err) => {
         // Write the Projects README to the README which is used in the release
         fs.readFile("../README.md", "utf8", (err, data) => {
-            fs.writeFileSync("/packages/patchright/README.md", data, "utf8", (err) => {});
+            fs.writeFileSync("packages/patchright/README.md", data, "utf8", (err) => {});
         });
-        fs.writeFileSync("/packages/patchright-core/README.md", "# patchright-core\n\nThis package contains the no-browser flavor of [Patchright-NodeJS](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-nodejs).", "utf8", (err) => {});
+        fs.writeFileSync("packages/patchright-core/README.md", "# patchright-core\n\nThis package contains the no-browser flavor of [Patchright-NodeJS](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-nodejs).", "utf8", (err) => {});
 
         // Package.Json Files
         // playwright-core/package.json
@@ -155,6 +155,6 @@ fs.rename("packages/playwright-core", "packages/patchright-core", (err) => {
         });
 
         // Usage example: pass the directory path as an argument
-        renameImportsAndExportsInDirectory("./packages/patchright");
+        renameImportsAndExportsInDirectory("packages/patchright");
     })
 })


### PR DESCRIPTION
Fix this [GitHub Actions](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright-nodejs/actions/runs/11912478962/job/33196150699) error:

```
Error: ENOENT: no such file or directory, open '/packages/patchright-core/README.md'
    at Object.openSync (node:fs:596:3)
    at Module.writeFileSync (node:fs:2322:35)
    at file:///home/runner/work/patchright-nodejs/patchright-nodejs/patchright_nodejs_rebranding.js:104:12
    at FSReqCallback.oncomplete (node:fs:192:23) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/packages/patchright-core/README.md'
}
```