### PR TITLE
Fix incorrect reference to 'playwright' in babelBundleImpl.js

### DIFF
--- a/patchright_nodejs_rebranding.js
+++ b/patchright_nodejs_rebranding.js
@@ -154,6 +154,26 @@ fs.rename("packages/playwright-core", "packages/patchright-core", (err) => {
             fs.writeFile("packages/patchright/lib/transform/esmUtils.js", updatedContent, 'utf8', (err) => {});
         });
 
+        // Read the content of node_modules/patchright/lib/transform/babelBundleImpl.js
+        fs.readFile("node_modules/patchright/lib/transform/babelBundleImpl.js", "utf8", (err, data) => {
+            if (err) {
+                console.error("Error reading file:", err);
+                return;
+            }
+
+            // Replace the incorrect mention of 'playwright' with 'patchright'
+            const updatedContent = data.replace(/playwright/g, "patchright");
+
+            // Save the updated content back to the file
+            fs.writeFile("node_modules/patchright/lib/transform/babelBundleImpl.js", updatedContent, "utf8", (err) => {
+                if (err) {
+                    console.error("Error writing file:", err);
+                } else {
+                    console.log("File updated successfully.");
+                }
+            });
+        });
+
         // Usage example: pass the directory path as an argument
         renameImportsAndExportsInDirectory("packages/patchright");
     })


### PR DESCRIPTION
Fixes #4

Update `patchright_nodejs_rebranding.js` to correct the reference to "playwright" in `babelBundleImpl.js`.

* Read the content of `node_modules/patchright/lib/transform/babelBundleImpl.js`.
* Replace the incorrect mention of 'playwright' with 'patchright'.
* Save the updated content back to the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Kaliiiiiiiiii-Vinyzu/patchright-nodejs/pull/8?shareId=4a4593fe-7d60-41cb-ad6c-7aec365fbba8).