### PR TITLE
Use route.fallback for installInjectRoute to support custom route handlers

### DIFF
--- a/patchright_nodejs_patch.js
+++ b/patchright_nodejs_patch.js
@@ -56,12 +56,12 @@ clientBrowserContextInstallInjectRouteMethod.setBodyText(`if (this.routeInjectin
     try {
       if (route.request().resourceType() === 'document' && route.request().url().startsWith('http')) {
           const protocol = route.request().url().split(':')[0];
-          await route.continue({ url: protocol + '://patchright-init-script-inject.internal/' });
+          await route.fallback({ url: protocol + '://patchright-init-script-inject.internal/' });
       } else {
-          await route.continue();
+          await route.fallback();
       }
   } catch (error) {
-      await route.continue();
+      await route.fallback();
   }
 });`);
 
@@ -101,12 +101,12 @@ await this.route('**/*', async route => {
   try {
     if (route.request().resourceType() === 'document' && route.request().url().startsWith('http')) {
         const protocol = route.request().url().split(':')[0];
-        await route.continue({ url: protocol + '://patchright-init-script-inject.internal/' });
+        await route.fallback({ url: protocol + '://patchright-init-script-inject.internal/' });
     } else {
-        await route.continue();
+        await route.fallback();
     }
 } catch (error) {
-    await route.continue();
+    await route.fallback();
   }
 });`);
 


### PR DESCRIPTION
In Playwright a request is delivered only to the first handler that matches and doesn’t call route.fallback(). Because Patchright’s handler runs first, other route handlers never sees the traffic.

For example after using Patchright with success; images or other resources were no longer blocked from context.route handler