### PR TITLE
fix: make isolatedContext arg patching resilient to upstream evaluate() changes

### DIFF
--- a/client_patches/framePatch.ts
+++ b/client_patches/framePatch.ts
@@ -1,5 +1,5 @@
 import { type Project, SyntaxKind } from "ts-morph";
-import { assertDefined } from "./utils.ts";
+import { addChannelCallProperty, assertDefined, bumpAssertMaxArguments } from "./utils.ts";
 
 // ---------------
 // client/frame.ts
@@ -39,21 +39,16 @@ export function patchFrame(project: Project) {
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("assertMaxArguments")
 		)
-	);
-	evaluateAssertCall.replaceWithText(evaluateAssertCall.getText().replace("2", "3"));
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	bumpAssertMaxArguments(evaluateAssertCall);
 	// Modify the function call inside the return statement to include 'isolatedContext'
 	const evaluateExpressionCall = assertDefined(
 		evaluateMethod.getFirstDescendant(node =>
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("this._channel.evaluateExpression")
 		)
-	);
-	evaluateExpressionCall.replaceWithText(
-		evaluateExpressionCall.getText().replace(
-			/(\{[\s\S]*?arg:\s*serializeArgument\(arg\))/,
-			"$1, isolatedContext: isolatedContext"
-		)
-	);
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	addChannelCallProperty(evaluateExpressionCall, "isolatedContext", "isolatedContext");
 
 	// -- evaluateHandle Method --
 	const evaluateHandleMethod = frameClass.getMethodOrThrow("evaluateHandle");
@@ -67,21 +62,16 @@ export function patchFrame(project: Project) {
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("assertMaxArguments")
 		)
-	);
-	evaluateHandleAssertCall.replaceWithText(evaluateHandleAssertCall.getText().replace("2", "3"));
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	bumpAssertMaxArguments(evaluateHandleAssertCall);
 	// Modify the function call inside the return statement to include 'isolatedContext'
 	const evaluateHandleExpressionCall = assertDefined(
 		evaluateHandleMethod.getFirstDescendant(node =>
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("this._channel.evaluateExpression")
 		)
-	);
-	evaluateHandleExpressionCall.replaceWithText(
-		evaluateHandleExpressionCall.getText().replace(
-			/(\{[\s\S]*?arg:\s*serializeArgument\(arg\))/,
-			"$1, isolatedContext: isolatedContext"
-		)
-	);
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	addChannelCallProperty(evaluateHandleExpressionCall, "isolatedContext", "isolatedContext");
 
 	// -- $$eval Method --
 	const evalOnSelectorMethod = frameClass.getMethodOrThrow("$$eval");
@@ -95,19 +85,14 @@ export function patchFrame(project: Project) {
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("assertMaxArguments")
 		)
-	);
-	evalOnSelectorAssertCall.replaceWithText(evalOnSelectorAssertCall.getText().replace("3", "4"));
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	bumpAssertMaxArguments(evalOnSelectorAssertCall);
 	// Modify the function call inside the return statement to include 'isolatedContext'
 	const evalOnSelectorExpressionCall = assertDefined(
 		evalOnSelectorMethod.getFirstDescendant(node =>
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("this._channel.evalOnSelectorAll")
 		)
-	);
-	evalOnSelectorExpressionCall.replaceWithText(
-		evalOnSelectorExpressionCall.getText().replace(
-			/(\{[\s\S]*?arg:\s*serializeArgument\(arg\))/,
-			"$1, isolatedContext: isolatedContext"
-		)
-	);
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	addChannelCallProperty(evalOnSelectorExpressionCall, "isolatedContext", "isolatedContext");
 }

--- a/client_patches/jsHandlePatch.ts
+++ b/client_patches/jsHandlePatch.ts
@@ -1,4 +1,5 @@
-import type { Project } from "ts-morph";
+import { type Project, SyntaxKind } from "ts-morph";
+import { addChannelCallProperty, assertDefined } from "./utils.ts";
 
 // ------------------
 // client/jsHandle.ts
@@ -11,21 +12,23 @@ export function patchJsHandle(project: Project) {
 	const jsHandleClass = jsHandleSourceFile.getClassOrThrow("JSHandle");
 
 	// -- evaluate Method --
+	// Note: we intentionally add the `isolatedContext` parameter and then only inject a single
+	// property into the existing `_channel.evaluateExpression(...)` call (via AST, not text
+	// replacement/full-body rewrite), so we don't clobber whatever upstream does around it
+	// (e.g. assertEvaluateOptions, serializeArgumentWithCallbacks, the `kNoTimeout` argument).
 	const evaluateMethod = jsHandleClass.getMethodOrThrow("evaluate");
 	evaluateMethod.addParameter({
 		name: "isolatedContext",
 		type: "boolean",
 		initializer: "true",
 	});
-  evaluateMethod.setBodyText(`
-    const result = await this._channel.evaluateExpression({
-      expression: String(pageFunction),
-      isFunction: typeof pageFunction === 'function',
-      arg: serializeArgument(arg),
-      isolatedContext: isolatedContext,
-    });
-    return parseResult(result.value);
-  `);
+	const evaluateExpressionCall = assertDefined(
+		evaluateMethod.getFirstDescendant(node =>
+			node.isKind(SyntaxKind.CallExpression) &&
+			node.getText().includes("this._channel.evaluateExpression")
+		)
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	addChannelCallProperty(evaluateExpressionCall, "isolatedContext", "isolatedContext");
 
 	// -- evaluateHandle Method --
 	const evaluateHandleMethod = jsHandleClass.getMethodOrThrow("evaluateHandle");
@@ -34,13 +37,11 @@ export function patchJsHandle(project: Project) {
 		type: "boolean",
 		initializer: "true",
 	});
-  evaluateHandleMethod.setBodyText(`
-    const result = await this._channel.evaluateExpressionHandle({
-      expression: String(pageFunction),
-      isFunction: typeof pageFunction === 'function',
-      arg: serializeArgument(arg),
-      isolatedContext: isolatedContext,
-    });
-    return JSHandle.from(result.handle) as any as structs.SmartHandle<R>;
-  `);
+	const evaluateHandleExpressionCall = assertDefined(
+		evaluateHandleMethod.getFirstDescendant(node =>
+			node.isKind(SyntaxKind.CallExpression) &&
+			node.getText().includes("this._channel.evaluateExpression")
+		)
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	addChannelCallProperty(evaluateHandleExpressionCall, "isolatedContext", "isolatedContext");
 }

--- a/client_patches/locatorPatch.ts
+++ b/client_patches/locatorPatch.ts
@@ -37,7 +37,7 @@ export function patchLocator(project: Project) {
 							isFunction: typeof pageFunction === "function",
 							arg: serializeArgument(arg),
 							isolatedContext: isolatedContext,
-						})
+						}, kNoTimeout)
 					).value
 				),
 			{ title: "Evaluate", timeout: options?.timeout }
@@ -65,7 +65,7 @@ export function patchLocator(project: Project) {
 							isFunction: typeof pageFunction === "function",
 							arg: serializeArgument(arg),
 							isolatedContext: isolatedContext,
-						})
+						}, kNoTimeout)
 					).handle
 				) as any as structs.SmartHandle<R>,
 			{ title: "Evaluate", timeout: options?.timeout }

--- a/client_patches/pagePatch.ts
+++ b/client_patches/pagePatch.ts
@@ -1,5 +1,5 @@
 import { type Project, SyntaxKind } from "ts-morph";
-import { assertDefined } from "./utils.ts";
+import { assertDefined, bumpAssertMaxArguments } from "./utils.ts";
 
 // --------------
 // client/page.ts
@@ -58,19 +58,20 @@ export function patchPage(project: Project) {
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("assertMaxArguments")
 		)
-	);
-	evaluateAssertCall.replaceWithText(evaluateAssertCall.getText().replace("2", "3"));
-	// Modify the function call inside the return statement to include 'isolatedContext'
-	const evaluateReturnStatement = assertDefined(
-		evaluateMethod.getFirstDescendant(node => node.isKind(SyntaxKind.ReturnStatement))
-	);
-	evaluateReturnStatement.replaceWithText(
-		evaluateReturnStatement.getText().replace(
-			"this._mainFrame.evaluate(pageFunction, arg)",
-			"this._mainFrame.evaluate(pageFunction, arg, isolatedContext)"
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	bumpAssertMaxArguments(evaluateAssertCall);
+	// Modify the function call inside the return statement to include 'isolatedContext', by
+	// appending an argument to the existing `this._mainFrame.evaluate(...)` call via AST rather
+	// than matching its exact current argument list as text (which breaks whenever upstream adds
+	// its own new arguments, e.g. `options`).
+	const evaluateMainFrameCall = assertDefined(
+		evaluateMethod.getFirstDescendant(node =>
+			node.isKind(SyntaxKind.CallExpression) &&
+			node.getText().startsWith("this._mainFrame.evaluate(")
 		)
-	);
-	
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	evaluateMainFrameCall.addArgument("isolatedContext");
+
 	// -- evaluateHandle Method --
 	const evaluateHandleMethod = pageClass.getMethodOrThrow("evaluateHandle");
 	evaluateHandleMethod.addParameter({
@@ -83,16 +84,14 @@ export function patchPage(project: Project) {
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("assertMaxArguments")
 		)
-	);
-	evaluateHandleAssertCall.replaceWithText(evaluateHandleAssertCall.getText().replace("2", "3"));
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	bumpAssertMaxArguments(evaluateHandleAssertCall);
 	// Modify the function call inside the return statement to include 'isolatedContext'
-	const evaluateHandleReturnStatement = assertDefined(
-		evaluateHandleMethod.getFirstDescendant(node => node.isKind(SyntaxKind.ReturnStatement))
-	);
-	evaluateHandleReturnStatement.replaceWithText(
-		evaluateHandleReturnStatement.getText().replace(
-			"this._mainFrame.evaluateHandle(pageFunction, arg)",
-			"this._mainFrame.evaluateHandle(pageFunction, arg, isolatedContext)"
+	const evaluateHandleMainFrameCall = assertDefined(
+		evaluateHandleMethod.getFirstDescendant(node =>
+			node.isKind(SyntaxKind.CallExpression) &&
+			node.getText().startsWith("this._mainFrame.evaluateHandle(")
 		)
-	);
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	evaluateHandleMainFrameCall.addArgument("isolatedContext");
 }

--- a/client_patches/utils.ts
+++ b/client_patches/utils.ts
@@ -1,4 +1,31 @@
+import { type CallExpression, Node } from "ts-morph";
+
 export function assertDefined<T>(value: T | undefined | null, name?: string): T {
 	if (value == null) throw new Error(`Required value${name ? ` "${name}"` : ""} is null or undefined`);
 	return value;
+}
+
+// Bumps the numeric max-argument-count literal inside an `assertMaxArguments(arguments.length, N)`
+// call by 1, regardless of what N currently is. A fixed string replace (e.g. "2" -> "3") is fragile:
+// it silently no-ops whenever upstream Playwright has already changed N on its own (e.g. by adding a
+// new `options` parameter before the one Patchright appends), leaving the count too low and causing
+// the extra Patchright argument to be swallowed by whatever parameter comes right before it.
+export function bumpAssertMaxArguments(call: CallExpression) {
+	const countArg = call.getArguments()[1];
+	if (!countArg) throw new Error(`assertMaxArguments call has no count argument: ${call.getText()}`);
+	const current = Number(countArg.getText());
+	if (Number.isNaN(current))
+		throw new Error(`assertMaxArguments count is not a numeric literal: ${countArg.getText()}`);
+	countArg.replaceWithText(String(current + 1));
+}
+
+// Adds a property (e.g. `isolatedContext: isolatedContext`) to the object-literal argument of a
+// channel call (e.g. `this._channel.evaluateExpression({ ... }, kNoTimeout)`) via proper AST
+// manipulation, rather than regex-matching the object literal's exact source text. The latter breaks
+// silently (no error, property just never gets added) whenever upstream renames an inner expression,
+// e.g. `arg: serializeArgument(arg)` becoming `arg: serializedArg`.
+export function addChannelCallProperty(call: CallExpression, propertyName: string, propertyValue: string) {
+	const objectArg = call.getArguments().find(Node.isObjectLiteralExpression);
+	if (!objectArg) throw new Error(`Could not find object-literal argument in call: ${call.getText()}`);
+	if (!objectArg.getProperty(propertyName)) objectArg.addPropertyAssignment({ name: propertyName, initializer: propertyValue });
 }

--- a/client_patches/workerPatch.ts
+++ b/client_patches/workerPatch.ts
@@ -1,5 +1,5 @@
 import { type Project, SyntaxKind } from "ts-morph";
-import { assertDefined } from "./utils.ts";
+import { addChannelCallProperty, assertDefined, bumpAssertMaxArguments } from "./utils.ts";
 
 // ----------------
 // client/worker.ts
@@ -24,20 +24,15 @@ export function patchWorker(project: Project) {
 			node.getText().includes("assertMaxArguments")
 		)
 	);
-	evaluateAssertCall.replaceWithText(evaluateAssertCall.getText().replace("2", "3"));
+	bumpAssertMaxArguments(evaluateAssertCall.asKindOrThrow(SyntaxKind.CallExpression));
 	// Modify the function call inside the return statement to include 'isolatedContext'
 	const evaluateExpressionCall = assertDefined(
 		evaluateMethod.getFirstDescendant(node =>
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("this._channel.evaluateExpression")
 		)
-	);
-	evaluateExpressionCall.replaceWithText(
-		evaluateExpressionCall.getText().replace(
-			/(\{[\s\S]*?arg:\s*serializeArgument\(arg\))/,
-			"$1, isolatedContext: isolatedContext"
-		)
-	);
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	addChannelCallProperty(evaluateExpressionCall, "isolatedContext", "isolatedContext");
 	
 	// -- evaluateHandle Method --
 	const evaluateHandleMethod = workerClass.getMethodOrThrow("evaluateHandle");
@@ -52,18 +47,13 @@ export function patchWorker(project: Project) {
 			node.getText().includes("assertMaxArguments")
 		)
 	);
-	evaluateHandleAssertCall.replaceWithText(evaluateHandleAssertCall.getText().replace("2", "3"));
+	bumpAssertMaxArguments(evaluateHandleAssertCall.asKindOrThrow(SyntaxKind.CallExpression));
 	// Modify the function call inside the return statement to include 'isolatedContext'
 	const evaluateHandleExpressionCall = assertDefined(
 		evaluateHandleMethod.getFirstDescendant(node =>
 			node.isKind(SyntaxKind.CallExpression) &&
 			node.getText().includes("this._channel.evaluateExpression")
 		)
-	);
-	evaluateHandleExpressionCall.replaceWithText(
-		evaluateHandleExpressionCall.getText().replace(
-			/(\{[\s\S]*?arg:\s*serializeArgument\(arg\))/,
-			"$1, isolatedContext: isolatedContext"
-		)
-	);
+	).asKindOrThrow(SyntaxKind.CallExpression);
+	addChannelCallProperty(evaluateHandleExpressionCall, "isolatedContext", "isolatedContext");
 }


### PR DESCRIPTION
## Problem

Playwright v1.62 added a new `options?: EvaluateOptions` parameter to
`Frame`/`Page`/`JSHandle` `evaluate()`/`evaluateHandle()`, right before the
slot where Patchright appends its own `isolatedContext` flag:

```diff
- async evaluate<R, Arg>(pageFunction: ..., arg?: Arg): Promise<R> {
-   assertMaxArguments(arguments.length, 2);
-   ... arg: serializeArgument(arg) ...
+ async evaluate<R, Arg>(pageFunction: ..., arg?: Arg, options?: EvaluateOptions): Promise<R> {
+   assertMaxArguments(arguments.length, 3);
+   const serializedArg = options?.exposeFunctions ? ... : serializeArgument(arg);
+   ... arg: serializedArg ...
```

The existing patches located their insertion points via fixed text/regex
matching against the *old* shape:
- `assertMaxArguments(...).replace("2", "3")` — a no-op once upstream's own
  count is already `3`, so it stays one short of the `4` Patchright needs.
- `arg: serializeArgument(arg)` regex — no longer matches once upstream
  renamed the inlined call to a `serializedArg` variable, so `isolatedContext`
  is silently never added to the channel call at all.
- Return-statement text matches like
  `"this._mainFrame.evaluate(pageFunction, arg)"` — no longer match once
  upstream's own call already forwards `options` as a 3rd argument.

None of these fail loudly (`.replace()` on a non-matching string is a
silent no-op), so the driver builds and patches cleanly, but every
`evaluate()` call at runtime throws:

```
Error: Too many arguments. If you need to pass more than 1 argument to
the function wrap them in an object.
```

because the caller-supplied `isolatedContext` value lands in the newly
inserted `options` parameter position instead.

## Fix

Add two small AST-based helpers in `client_patches/utils.ts`:

- `bumpAssertMaxArguments(call)` — reads the existing numeric literal in
  `assertMaxArguments(arguments.length, N)` and increments it by 1,
  instead of assuming what `N` currently is.
- `addChannelCallProperty(call, name, value)` — finds the object-literal
  argument of a channel call (e.g. `this._channel.evaluateExpression({...})`)
  via `Node.isObjectLiteralExpression` and adds the property through the
  AST, instead of regexing the object literal's exact source text.

Applied to `framePatch.ts`, `pagePatch.ts`, `jsHandlePatch.ts`, and
`workerPatch.ts` (the latter unaffected by this specific upstream change,
but hardened for consistency/future-proofing). `pagePatch.ts`'s
`this._mainFrame.evaluate(...)` forwarding call is now patched by
appending an argument via `CallExpression.addArgument()` rather than
matching the full call text. `locatorPatch.ts`'s hand-written
`evaluate`/`evaluateHandle` bodies were also missing the new required
`kNoTimeout` second argument to `_channel.evaluateExpression(...)`
(the channel's `options: TimeoutOptions` parameter is non-optional as of
v1.62), which was likewise crashing at runtime.

## Testing

Verified against Playwright v1.62.1: after this fix (combined with the
sibling fixes in the main `patchright` repo for #228/#229), `evaluate()`/
`evaluateHandle()`/`$$eval()`/`Locator.evaluate()` all work correctly with
both default and explicit `isolatedContext` values, and the full
`detection_smoke_test.mjs` plus ~800 of Playwright's own
selectors/locators/frames/expect chromium-page tests pass.

Related: Kaliiiiiiiiii-Vinyzu/patchright#228, Kaliiiiiiiiii-Vinyzu/patchright#229